### PR TITLE
extend device checks to allow data on device

### DIFF
--- a/sbi/inference/snle/snle_base.py
+++ b/sbi/inference/snle/snle_base.py
@@ -77,7 +77,10 @@ class LikelihoodEstimator(NeuralInference, ABC):
         self._summary.update({"mcmc_times": []})  # type: ignore
 
     def append_simulations(
-        self, theta: Tensor, x: Tensor, from_round: int = 0,
+        self,
+        theta: Tensor,
+        x: Tensor,
+        from_round: int = 0,
     ) -> "LikelihoodEstimator":
         r"""
         Store parameters and simulation outputs to use them for later training.
@@ -100,7 +103,7 @@ class LikelihoodEstimator(NeuralInference, ABC):
             NeuralInference object (returned so that this function is chainable).
         """
 
-        validate_theta_and_x(theta, x)
+        theta, x = validate_theta_and_x(theta, x, training_device=self._device)
 
         self._theta_roundwise.append(theta)
         self._x_roundwise.append(x)
@@ -186,7 +189,8 @@ class LikelihoodEstimator(NeuralInference, ABC):
         self._neural_net.to(self._device)
         if not resume_training:
             self.optimizer = optim.Adam(
-                list(self._neural_net.parameters()), lr=learning_rate,
+                list(self._neural_net.parameters()),
+                lr=learning_rate,
             )
             self.epoch, self._val_log_prob = 0, float("-Inf")
 
@@ -208,7 +212,8 @@ class LikelihoodEstimator(NeuralInference, ABC):
                 loss.backward()
                 if clip_max_norm is not None:
                     clip_grad_norm_(
-                        self._neural_net.parameters(), max_norm=clip_max_norm,
+                        self._neural_net.parameters(),
+                        max_norm=clip_max_norm,
                     )
                 self.optimizer.step()
 
@@ -243,7 +248,10 @@ class LikelihoodEstimator(NeuralInference, ABC):
 
         # Update TensorBoard and summary dict.
         self._summarize(
-            round_=self._round, x_o=None, theta_bank=theta, x_bank=x,
+            round_=self._round,
+            x_o=None,
+            theta_bank=theta,
+            x_bank=x,
         )
 
         # Update description for progress bar.

--- a/sbi/inference/snpe/snpe_base.py
+++ b/sbi/inference/snpe/snpe_base.py
@@ -2,6 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
+import logging
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from typing import Any, Callable, Dict, Optional, Union
@@ -37,7 +38,7 @@ class PosteriorEstimator(NeuralInference, ABC):
         logging_level: Union[int, str] = "WARNING",
         summary_writer: Optional[SummaryWriter] = None,
         show_progress_bars: bool = True,
-        **unused_args
+        **unused_args,
     ):
         """Base class for Sequential Neural Posterior Estimation methods.
 
@@ -109,7 +110,7 @@ class PosteriorEstimator(NeuralInference, ABC):
             NeuralInference object (returned so that this function is chainable).
         """
 
-        validate_theta_and_x(theta, x)
+        theta, x = validate_theta_and_x(theta, x, training_device=self._device)
         self._check_proposal(proposal)
 
         if (
@@ -252,7 +253,13 @@ class PosteriorEstimator(NeuralInference, ABC):
             self._neural_net = self._build_neural_net(
                 theta[self.train_indices], x[self.train_indices]
             )
-            self._neural_net.to(self._device)
+            # If data on training device already move net as well.
+            if (
+                not self._device == "cpu"
+                and f"{x.device.type}:{x.device.index}" == self._device
+            ):
+                self._neural_net.to(self._device)
+
             test_posterior_net_for_multi_d_x(self._neural_net, theta, x)
             self._x_shape = x_shape_from_simulation(x)
 

--- a/sbi/inference/snre/snre_base.py
+++ b/sbi/inference/snre/snre_base.py
@@ -81,7 +81,10 @@ class RatioEstimator(NeuralInference, ABC):
         self._summary.update({"mcmc_times": []})  # type: ignore
 
     def append_simulations(
-        self, theta: Tensor, x: Tensor, from_round: int = 0,
+        self,
+        theta: Tensor,
+        x: Tensor,
+        from_round: int = 0,
     ) -> "RatioEstimator":
         r"""
         Store parameters and simulation outputs to use them for later training.
@@ -103,7 +106,7 @@ class RatioEstimator(NeuralInference, ABC):
             NeuralInference object (returned so that this function is chainable).
         """
 
-        validate_theta_and_x(theta, x)
+        theta, x = validate_theta_and_x(theta, x, training_device=self._device)
 
         self._theta_roundwise.append(theta)
         self._x_roundwise.append(x)
@@ -193,7 +196,8 @@ class RatioEstimator(NeuralInference, ABC):
 
         if not resume_training:
             self.optimizer = optim.Adam(
-                list(self._neural_net.parameters()), lr=learning_rate,
+                list(self._neural_net.parameters()),
+                lr=learning_rate,
             )
             self.epoch, self._val_log_prob = 0, float("-Inf")
 
@@ -213,7 +217,8 @@ class RatioEstimator(NeuralInference, ABC):
                 loss.backward()
                 if clip_max_norm is not None:
                     clip_grad_norm_(
-                        self._neural_net.parameters(), max_norm=clip_max_norm,
+                        self._neural_net.parameters(),
+                        max_norm=clip_max_norm,
                     )
                 self.optimizer.step()
 
@@ -247,7 +252,10 @@ class RatioEstimator(NeuralInference, ABC):
 
         # Update TensorBoard and summary dict.
         self._summarize(
-            round_=self._round, x_o=None, theta_bank=theta, x_bank=x,
+            round_=self._round,
+            x_o=None,
+            theta_bank=theta,
+            x_bank=x,
         )
 
         # Update description for progress bar.

--- a/sbi/utils/user_input_checks.py
+++ b/sbi/utils/user_input_checks.py
@@ -2,6 +2,7 @@
 # under the Affero General Public License v3, see <https://www.gnu.org/licenses/>.
 
 
+import logging
 import warnings
 from typing import Any, Callable, Optional, Sequence, Tuple, Union, cast
 
@@ -367,7 +368,9 @@ def check_prior_support(prior):
 
 
 def process_simulator(
-    user_simulator: Callable, prior, is_numpy_simulator: bool,
+    user_simulator: Callable,
+    prior,
+    is_numpy_simulator: bool,
 ) -> Callable:
     """Return a simulator that meets the requirements for usage in sbi.
 
@@ -471,7 +474,10 @@ def process_x(x: Tensor, x_shape: torch.Size) -> Tensor:
     return x
 
 
-def prepare_for_sbi(simulator: Callable, prior,) -> Tuple[Callable, Distribution]:
+def prepare_for_sbi(
+    simulator: Callable,
+    prior,
+) -> Tuple[Callable, Distribution]:
     """Prepare simulator, prior and for usage in sbi.
 
     One of the goals is to allow you to use sbi with inputs computed in numpy.
@@ -553,7 +559,9 @@ def check_estimator_arg(estimator: Union[str, Callable]) -> None:
     )
 
 
-def validate_theta_and_x(theta: Any, x: Any) -> None:
+def validate_theta_and_x(
+    theta: Any, x: Any, training_device: str
+) -> Tuple[Tensor, Tensor]:
     r"""
     Checks if the passed $(\theta, x)$ are valid.
 
@@ -569,6 +577,7 @@ def validate_theta_and_x(theta: Any, x: Any) -> None:
     Args:
         theta: Parameters.
         x: Simulation outputs.
+        training_device: Training device for net.
     """
     assert isinstance(theta, Tensor), "Parameters theta must be a `torch.Tensor`."
     assert isinstance(x, Tensor), "Simulator output must be a `torch.Tensor`."
@@ -582,6 +591,17 @@ def validate_theta_and_x(theta: Any, x: Any) -> None:
     # to give more explicit errors.
     assert theta.dtype == float32, "Type of parameters must be float32."
     assert x.dtype == float32, "Type of simulator outputs must be float32."
+
+    simulations_device = f"{x.device.type}:{x.device.index}"
+    if not simulations_device == "cpu" and training_device == "cpu":
+        logging.warning(
+            """Simulations are on {self.simulations_device} but training device is
+            set to {training_device}, moving data to device to {training_device}."""
+        )
+        x = x.to(training_device)
+        theta = theta.to(training_device)
+
+    return theta, x
 
 
 def test_posterior_net_for_multi_d_x(net: nn.Module, theta: Tensor, x: Tensor) -> None:

--- a/tests/user_input_checks_test.py
+++ b/tests/user_input_checks_test.py
@@ -90,7 +90,10 @@ def matrix_simulator(theta):
 @pytest.mark.parametrize(
     "wrapper, prior",
     (
-        (CustomPytorchWrapper, UserNumpyUniform(zeros(3), ones(3), return_numpy=True),),
+        (
+            CustomPytorchWrapper,
+            UserNumpyUniform(zeros(3), ones(3), return_numpy=True),
+        ),
         (ScipyPytorchWrapper, multivariate_normal()),
         (ScipyPytorchWrapper, uniform()),
         (ScipyPytorchWrapper, beta(a=1, b=1)),
@@ -140,7 +143,8 @@ def test_reinterpreted_batch_dim_prior():
             Uniform(zeros((1, 3)), ones((1, 3))), marks=pytest.mark.xfail
         ),  # batch shape > 1.
         pytest.param(
-            MultivariateNormal(zeros(3, 3), eye(3)), marks=pytest.mark.xfail,
+            MultivariateNormal(zeros(3, 3), eye(3)),
+            marks=pytest.mark.xfail,
         ),  # batch shape > 1.
         pytest.param(
             Uniform(zeros(3), ones(3)), marks=pytest.mark.xfail
@@ -168,7 +172,11 @@ def test_process_prior(prior):
 
 
 @pytest.mark.parametrize(
-    "x, x_shape", ((ones(3), torch.Size([1, 3])), (ones(1, 3), torch.Size([1, 3])),),
+    "x, x_shape",
+    (
+        (ones(3), torch.Size([1, 3])),
+        (ones(1, 3), torch.Size([1, 3])),
+    ),
 )
 def test_process_x(x, x_shape):
     process_x(x, x_shape)
@@ -181,7 +189,10 @@ def test_process_x(x, x_shape):
         (diagonal_linear_gaussian, BoxUniform(zeros(2), ones(2))),
         (numpy_linear_gaussian, UserNumpyUniform(zeros(2), ones(2), True)),
         (linear_gaussian_no_batch, BoxUniform(zeros(2), ones(2))),
-        pytest.param(list_simulator, BoxUniform(zeros(2), ones(2)),),
+        pytest.param(
+            list_simulator,
+            BoxUniform(zeros(2), ones(2)),
+        ),
     ),
 )
 def test_process_simulator(simulator: Callable, prior: Distribution):
@@ -201,7 +212,10 @@ def test_process_simulator(simulator: Callable, prior: Distribution):
 @pytest.mark.parametrize(
     "simulator, prior",
     (
-        (linear_gaussian_no_batch, BoxUniform(zeros(3), ones(3)),),
+        (
+            linear_gaussian_no_batch,
+            BoxUniform(zeros(3), ones(3)),
+        ),
         (
             numpy_linear_gaussian,
             UserNumpyUniform(zeros(3), ones(3), return_numpy=True),
@@ -223,7 +237,10 @@ def test_process_simulator(simulator: Callable, prior: Distribution):
                 MultivariateNormal(zeros(2), eye(2)),
             ],
         ),
-        pytest.param(list_simulator, BoxUniform(zeros(3), ones(3)),),
+        pytest.param(
+            list_simulator,
+            BoxUniform(zeros(3), ones(3)),
+        ),
     ),
 )
 def test_prepare_sbi_problem(simulator: Callable, prior):
@@ -279,7 +296,11 @@ def test_inference_with_user_sbi_problems(user_simulator: Callable, user_prior):
     """
 
     simulator, prior = prepare_for_sbi(user_simulator, user_prior)
-    inference = SNPE_C(prior, density_estimator="maf", show_progress_bars=False,)
+    inference = SNPE_C(
+        prior,
+        density_estimator="maf",
+        show_progress_bars=False,
+    )
 
     # Run inference.
     theta, x = simulate_for_sbi(simulator, prior, 100)
@@ -495,22 +516,21 @@ def test_validate_theta_and_x_gpu():
 @pytest.mark.gpu
 @pytest.mark.parametrize("data_device", ("cpu", "cuda:0"))
 @pytest.mark.parametrize("training_device", ("cpu", "cuda:0"))
-def test_train_with_different_data_and_training_device(data_device,
-                                                       training_device):
+def test_train_with_different_data_and_training_device(data_device, training_device):
 
     assert torch.cuda.is_available(), "gpu geared test has no GPU available"
 
     num_dim = 2
 
     # simulator, prior = prepare_for_sbi(user_simulator, user_prior)
-    prior_ = MultivariateNormal(loc=torch.zeros(num_dim),
-                                covariance_matrix=torch.eye(num_dim))
+    prior_ = MultivariateNormal(
+        loc=torch.zeros(num_dim), covariance_matrix=torch.eye(num_dim)
+    )
     simulator, prior = prepare_for_sbi(diagonal_linear_gaussian, prior_)
 
-    inference = SNPE_C(prior,
-                       density_estimator="maf",
-                       show_progress_bars=False,
-                       device=training_device)
+    inference = SNPE_C(
+        prior, density_estimator="maf", show_progress_bars=False, device=training_device
+    )
 
     # Run inference.
     theta, x = simulate_for_sbi(simulator, prior, 100)
@@ -519,7 +539,7 @@ def test_train_with_different_data_and_training_device(data_device,
 
     _ = inference.train(max_num_epochs=2)
 
-    #check for default device for inference object
+    # Check for default device for inference object
     weights_device = next(inference._neural_net.parameters()).device
     assert torch.device(training_device) == weights_device
 


### PR DESCRIPTION
this cost me some headaches but now it should be possible to pass simulations to `sbi` that are already on the training device. 

